### PR TITLE
Add provenance for SIGNOR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,10 @@ missing-biolink-relation.ttl: sparql/reports/owl-missing-biolink-relation.rq cam
 all: cam-db-reasoned.jnl
 
 noctua-models.jnl: $(NOCTUA_MODELS_REPO)/models/*.ttl signor-models
+	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true signor-models &&\
+	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/set-provenance-to-signor.ru &&\
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true $(NOCTUA_MODELS_REPO)/models &&\
-	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/delete-non-production-models.ru &&\
-	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true signor-models
+	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/delete-non-production-models.ru
 
 noctua-models-inferences.nq: $(NOCTUA_MODELS_REPO)/models/*.ttl sparql/is-production.rq ontologies-merged.ttl
 	$(MAT) --ontology-file ontologies-merged.ttl --input $(NOCTUA_MODELS_REPO)/models --output $@ --output-graph-name '#inferred' --suffix-graph true --mark-direct-types true --output-indirect-types true --parallelism 20 --filter-graph-query sparql/is-production.rq --reasoner arachne

--- a/sparql/set-provenance-to-signor.ru
+++ b/sparql/set-provenance-to-signor.ru
@@ -9,7 +9,12 @@ PREFIX pav: <http://purl.org/pav/>
 # SIGNOR, and then load the remaining models.
 
 INSERT {
-  ?model pav:importedFrom <https://signor.uniroma2.it/>
+  # pav:importedFrom might be more accurate here, but I think
+  # sparql/delete-non-production-models.ru deletes models that
+  # don't have a pav:providedBy (which also seems to be what
+  # the triplestore largely uses), so let's use that to be
+  # consistent.
+  ?model pav:providedBy <https://signor.uniroma2.it/> .
 } WHERE {
   ?model rdf:type owl:Ontology .
   # When generating SIGNOR models, we set lego:modelstate,

--- a/sparql/set-provenance-to-signor.ru
+++ b/sparql/set-provenance-to-signor.ru
@@ -1,0 +1,20 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX lego: <http://geneontology.org/lego/>
+PREFIX pav: <http://purl.org/pav/>
+
+# This is a temporary fix to https://github.com/ExposuresProvider/cam-pipeline/issues/76 -- a more
+# permanent fix would require rewriting the SIGNOR to TTL converter to add provenance information.
+# Currently we import the SIGNOR models first, use this SPARQL UPDATE to mark them as imported from
+# SIGNOR, and then load the remaining models.
+
+UPDATE {
+  ?model pav:importedFrom <https://signor.uniroma2.it/>
+} WHERE {
+  ?model rdf:type owl:Ontology .
+  # When generating SIGNOR models, we set lego:modelstate,
+  # so we can use that to ensure we're only modifying models
+  # here.
+  ?model lego:modelstate ?modelstate
+}
+}

--- a/sparql/set-provenance-to-signor.ru
+++ b/sparql/set-provenance-to-signor.ru
@@ -17,4 +17,3 @@ UPDATE {
   # here.
   ?model lego:modelstate ?modelstate
 }
-}

--- a/sparql/set-provenance-to-signor.ru
+++ b/sparql/set-provenance-to-signor.ru
@@ -8,7 +8,7 @@ PREFIX pav: <http://purl.org/pav/>
 # Currently we import the SIGNOR models first, use this SPARQL UPDATE to mark them as imported from
 # SIGNOR, and then load the remaining models.
 
-UPDATE {
+INSERT {
   ?model pav:importedFrom <https://signor.uniroma2.it/>
 } WHERE {
   ?model rdf:type owl:Ontology .


### PR DESCRIPTION
This PR attempts to implement the temporary fix we described in https://github.com/ExposuresProvider/cam-pipeline/issues/76#issuecomment-1178023752 by (1) loading only the SIGNOR models into Blazegraph, (2) marking all the models as having SIGNOR provenance, and then (3) loading the remaining models.

I was unable to test this locally, but I'll get the instructions for running this on Sterling from Jim and try running it there.