### PR TITLE
Add Kubernetes CronJob file to repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,12 @@ SCALA_RUN=$(JAVA_ENV) scala-cli run --home /tools
 NOCTUA_MODELS_REPO=gene-data/noctua-models
 BIOLINK=2.1.0
 
-.PHONY: clean validate
+.PHONY: clean validate all
 
+all: cam-db-reasoned.jnl
 clean:
 	rm -rf gene-data
+	rm -rf noctua-models.jnl
 
 owlrl-datalog:
 	git clone https://github.com/balhoff/owlrl-datalog.git
@@ -63,13 +65,11 @@ missing-biolink-terms.ttl: sparql/reports/owl-missing-biolink-term.rq cam-db-rea
 missing-biolink-relation.ttl: sparql/reports/owl-missing-biolink-relation.rq cam-db-reasoned.jnl
 	$(BLAZEGRAPH-RUNNER) select --journal=cam-db-reasoned.jnl --properties=blazegraph.properties --outformat=TSV $< $@
 
-all: cam-db-reasoned.jnl
-
 $(NOCTUA_MODELS_REPO):
 	mkdir -p gene-data
 	git clone --depth 1 https://github.com/geneontology/noctua-models gene-data/noctua-models
 
-noctua-models.jnl: $(NOCTUA_MODELS_REPO) $(NOCTUA_MODELS_REPO)/models/*.ttl signor-models
+noctua-models.jnl: $(NOCTUA_MODELS_REPO) signor-models
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true signor-models &&\
 	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/set-provenance-to-signor.ru &&\
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true $(NOCTUA_MODELS_REPO)/models &&\

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ noctua-models.jnl: $(NOCTUA_MODELS_REPO) signor-models
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true $(NOCTUA_MODELS_REPO)/models &&\
 	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/delete-non-production-models.ru
 
-noctua-models-inferences.nq: $(NOCTUA_MODELS_REPO)/models/*.ttl sparql/is-production.rq ontologies-merged.ttl
+noctua-models-inferences.nq: $(NOCTUA_MODELS_REPO) sparql/is-production.rq ontologies-merged.ttl
 	$(MAT) --ontology-file ontologies-merged.ttl --input $(NOCTUA_MODELS_REPO)/models --output $@ --output-graph-name '#inferred' --suffix-graph true --mark-direct-types true --output-indirect-types true --parallelism 20 --filter-graph-query sparql/is-production.rq --reasoner arachne
 
 signor-models-inferences.nq: signor-models

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,11 @@ missing-biolink-relation.ttl: sparql/reports/owl-missing-biolink-relation.rq cam
 
 all: cam-db-reasoned.jnl
 
-noctua-models.jnl: $(NOCTUA_MODELS_REPO)/models/*.ttl signor-models
+$(NOCTUA_MODELS_REPO):
+	mkdir -p gene-data
+	git clone --depth 1 https://github.com/geneontology/noctua-models gene-data/noctua-models
+
+noctua-models.jnl: $(NOCTUA_MODELS_REPO) $(NOCTUA_MODELS_REPO)/models/*.ttl signor-models
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true signor-models &&\
 	$(BLAZEGRAPH-RUNNER) update --journal=$@ --properties=blazegraph.properties sparql/set-provenance-to-signor.ru &&\
 	$(BLAZEGRAPH-RUNNER) load --journal=$@ --properties=blazegraph.properties --informat=turtle --use-ontology-graph=true $(NOCTUA_MODELS_REPO)/models &&\

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -19,7 +19,7 @@ spec:
               limits:
                 cpu: '8'
                 memory: 150G
-            command: ["sh", "-c", "cd /workspace; rm -rf current; mkdir current; cd current; git clone https://github.com/NCATS-Tangerine/cam-pipeline.git; cd cam-pipeline; git checkout add-kubernetes; make all; rm -rf /workspace/success; mv /workspace/current /workspace/success"]
+            command: ["sh", "-c", "cd /workspace; rm -rf current; mkdir current; cd current; git clone https://github.com/NCATS-Tangerine/cam-pipeline.git; cd cam-pipeline; git checkout master; make all; rm -rf /workspace/success; mv /workspace/current /workspace/success"]
             volumeMounts:
             - mountPath: "/workspace"
               name: storage

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -27,13 +27,13 @@ spec:
           volumes:
           - name: storage
             persistentVolumeClaim:
-              claimName: cam-kp-build-pipeline-storage
+              claimName: build-cam-database-storage
       backoffLimit: 0
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: cam-kp-build-pipeline-storage
+  name: build-cam-database-storage
   labels:
     project: CAM-KP
     env: dev

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -16,7 +16,7 @@ spec:
               limits:
                 cpu: '8'
                 memory: 150G
-            command: ["sh", "-c", "cd /workspace; rm -rf current; mkdir current; cd current; git clone https://github.com/NCATS-Tangerine/cam-pipeline.git; cd cam-pipeline; git checkout use-materializer; mkdir gene-data; cd gene-data; git clone --depth 1 https://github.com/geneontology/noctua-models; cd ..; make all; rm -rf /workspace/success; mv /workspace/current /workspace/success"]
+            command: ["sh", "-c", "cd /workspace; rm -rf current; mkdir current; cd current; git clone https://github.com/NCATS-Tangerine/cam-pipeline.git; cd cam-pipeline; git checkout add-kubernetes; make all; rm -rf /workspace/success; mv /workspace/current /workspace/success"]
             volumeMounts:
             - mountPath: "/workspace"
               name: storage

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -2,6 +2,9 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: build-cam-database
+  labels:
+    project: CAM-KP
+    env: dev
 spec:
   schedule: "@weekly"
   concurrencyPolicy: Forbid
@@ -26,18 +29,18 @@ spec:
             persistentVolumeClaim:
               claimName: cam-kp-build-pipeline-storage
       backoffLimit: 0
-# ---
-# apiVersion: v1
-# kind: PersistentVolumeClaim
-# metadata:
-#   name: cam-kp-build-pipeline-storage
-#   labels:
-#     project: CAM-KP
-#     env: prod
-# spec:
-#   accessModes:
-#   - ReadWriteMany
-#   resources:
-#     requests:
-#       storage: 500G
-#   storageClassName: basic
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cam-kp-build-pipeline-storage
+  labels:
+    project: CAM-KP
+    env: dev
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1000G
+  storageClassName: basic

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: build-cam-database
+spec:
+  schedule: "@weekly"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: pipeline-tools
+            image: "renciorg/cam-pipeline-tools:v1.3"
+            resources:
+              limits:
+                cpu: '8'
+                memory: 150G
+            command: ["sh", "-c", "cd /workspace; rm -rf current; mkdir current; cd current; git clone https://github.com/NCATS-Tangerine/cam-pipeline.git; cd cam-pipeline; git checkout use-materializer; mkdir gene-data; cd gene-data; git clone --depth 1 https://github.com/geneontology/noctua-models; cd ..; make all; rm -rf /workspace/success; mv /workspace/current /workspace/success"]
+            volumeMounts:
+            - mountPath: "/workspace"
+              name: storage
+          restartPolicy: Never
+          volumes:
+          - name: storage
+            persistentVolumeClaim:
+              claimName: cam-kp-build-pipeline-storage
+      backoffLimit: 0
+# ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: cam-kp-build-pipeline-storage
+#   labels:
+#     project: CAM-KP
+#     env: prod
+# spec:
+#   accessModes:
+#   - ReadWriteMany
+#   resources:
+#     requests:
+#       storage: 500G
+#   storageClassName: basic


### PR DESCRIPTION
This PR adds the Kubernetes CronJob file to the repository. It moves one of the steps from the Kubernetes file into the Makefile. It seems to be mostly working -- I've tested one of the files generated by this job and it produces a small number of errors on CAM-KP-API (https://github.com/ExposuresProvider/cam-pipeline/issues/80, https://github.com/ExposuresProvider/cam-kp-api/issues/613) -- and I'd rather not delay this any further so that I can move on to trying to upgrade cam-pipeline to Biolink 3.

Before this is merged, the branch should be changed from `add-kubernetes` back to `master`.