### PR TITLE
Improve debugging of cam-pipeline on Kubernetes

### DIFF
--- a/kubernetes/build-cam-database-storage.yaml
+++ b/kubernetes/build-cam-database-storage.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: build-cam-database-storage
+  labels:
+    project: CAM-KP
+    env: dev
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1000G
+  storageClassName: basic

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: pipeline-tools
-            image: "renciorg/cam-pipeline-tools:v1.3"
+            image: "renciorg/cam-pipeline-tools:dev"
             resources:
               limits:
                 cpu: '8'

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -3,8 +3,7 @@ kind: CronJob
 metadata:
   name: build-cam-database
   labels:
-    project: CAM-KP
-    env: dev
+    app: cam-pipeline
 spec:
   schedule: "@weekly"
   concurrencyPolicy: Forbid

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -28,18 +28,3 @@ spec:
             persistentVolumeClaim:
               claimName: build-cam-database-storage
       backoffLimit: 0
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: build-cam-database-storage
-  labels:
-    project: CAM-KP
-    env: dev
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 1000G
-  storageClassName: basic

--- a/kubernetes/build-cam-database.yaml
+++ b/kubernetes/build-cam-database.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: pipeline-tools
-            image: "renciorg/cam-pipeline-tools:dev"
+            image: "renciorg/cam-pipeline-tools:v1.4"
             resources:
               limits:
                 cpu: '8'

--- a/kubernetes/debug-cam-database.yaml
+++ b/kubernetes/debug-cam-database.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: cam-pipeline-debug
+  labels:
+    app: cam-pipeline
 spec:
   containers:
   - name: pipeline-tools

--- a/kubernetes/debug-cam-database.yaml
+++ b/kubernetes/debug-cam-database.yaml
@@ -1,0 +1,24 @@
+# A Pod for debugging cam-pipeline outputs.
+# Assumes that there's a build-cam-database-storage PVC.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cam-pipeline-debug
+spec:
+  containers:
+  - name: pipeline-tools
+    image: "renciorg/cam-pipeline-tools:dev"
+    resources:
+      limits:
+        cpu: '8'
+        memory: 150G
+    command: ["sh", "-c", "while true; echo 'alive'; do sleep 10; done"]
+    volumeMounts:
+    - mountPath: "/workspace"
+      name: storage
+  restartPolicy: Never
+  volumes:
+  - name: storage
+    persistentVolumeClaim:
+      claimName: build-cam-database-storage

--- a/kubernetes/debug-cam-database.yaml
+++ b/kubernetes/debug-cam-database.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
   - name: pipeline-tools
-    image: "renciorg/cam-pipeline-tools:dev"
+    image: "renciorg/cam-pipeline-tools:v1.4"
     resources:
       limits:
         cpu: '8'


### PR DESCRIPTION
This PR does this by:
- Upgrading to cam-pipeline-tools:dev to pull in changes from https://github.com/ExposuresProvider/cam-pipeline-tools/pull/4 and https://github.com/ExposuresProvider/cam-pipeline-tools/pull/5
- Adding a Kubernetes Pod description that is identical to build-cam-database.yaml and that connects to the same PVC, but creates a single pod rather than a CronJob, and does not automatically start the build process. This can be used to fix errors on the PVC or to try something new before incorporating it into the build-cam-database CronJob.

This should be merged after #78