### PR TITLE
Make branch kg-tsv run on Sterling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ROBOT=$(ROBOT_ENV) robot
 JVM_ARGS=JVM_ARGS="-Xmx96G -XX:+UseParallelGC"
 ARQ=$(JVM_ARGS) arq
 
-SCALA_RUN=$(JAVA_ENV) COURSIER_CACHE=/home/cam/coursier-cache scala-cli run
+SCALA_RUN=$(JAVA_ENV) COURSIER_CACHE=/workspace/coursier-cache scala-cli run
 
 BIOLINK=v3.4.3
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-JAVA_ENV=JAVA_OPTS="-Xmx96G -XX:+UseParallelGC"
+JAVA_ENV=JAVA_OPTS="-Xmx96G -XX:+UseParallelGC -Dmaven.repo.local=/workspace/maven-local"
 BLAZEGRAPH-RUNNER=$(JAVA_ENV) blazegraph-runner
 
 ROBOT_ENV=ROBOT_JAVA_ARGS="-Xmx96G -XX:+UseParallelGC"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARQ=$(JVM_ARGS) arq
 
 SCALA_RUN=$(JAVA_ENV) COURSIER_CACHE=/home/cam/coursier-cache scala-cli run
 
-BIOLINK=v3.2.5
+BIOLINK=v3.4.3
 
 owlrl-datalog:
 	git clone https://github.com/balhoff/owlrl-datalog.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-JAVA_ENV=JAVA_OPTS="-Xmx96G -XX:+UseParallelGC -Dmaven.repo.local=/workspace/maven-local"
+JAVA_ENV=JAVA_OPTS="-Xmx96G -XX:+UseParallelGC"
 BLAZEGRAPH-RUNNER=$(JAVA_ENV) blazegraph-runner
 
 ROBOT_ENV=ROBOT_JAVA_ARGS="-Xmx96G -XX:+UseParallelGC"

--- a/kubernetes/build-cam-database-storage.yaml
+++ b/kubernetes/build-cam-database-storage.yaml
@@ -10,5 +10,5 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 500G
+      storage: 100G
   storageClassName: basic

--- a/kubernetes/build-cam-database-storage.yaml
+++ b/kubernetes/build-cam-database-storage.yaml
@@ -10,5 +10,5 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 1000G
+      storage: 500G
   storageClassName: basic

--- a/kubernetes/build-cam-database-storage.yaml
+++ b/kubernetes/build-cam-database-storage.yaml
@@ -10,5 +10,5 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 100G
+      storage: 500Gi
   storageClassName: basic

--- a/kubernetes/debug-cam-database.yaml
+++ b/kubernetes/debug-cam-database.yaml
@@ -10,11 +10,12 @@ metadata:
 spec:
   containers:
   - name: pipeline-tools
-    image: "renciorg/cam-pipeline-tools:v1.4"
+    image: "renciorg/cam-pipeline-tools:latest"
     resources:
       limits:
         cpu: '8'
         memory: 150G
+        ephemeral-storage: 10G
     command: ["sh", "-c", "while true; echo 'alive'; do sleep 10; done"]
     volumeMounts:
     - mountPath: "/workspace"

--- a/ontologies.ofn
+++ b/ontologies.ofn
@@ -20,7 +20,9 @@ Import(<http://purl.obolibrary.org/obo/eco/eco-base.owl>)
 Import(<http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-caro.owl>)
 Import(<http://purl.obolibrary.org/obo/uberon/bridge/cl-bridge-to-caro.owl>)
 Import(<http://purl.obolibrary.org/obo/go/extensions/go-bfo-bridge.owl>)
-Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl>)
+# Commented out on 2023-jun-19 by Gaurav: appears to be redundant with
+# http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl
+# Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl>)
 Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl>)
 Import(<http://purl.obolibrary.org/obo/wbbt/wbbt-base.owl>)
 Import(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-base.owl>)

--- a/ontologies.ofn
+++ b/ontologies.ofn
@@ -20,9 +20,7 @@ Import(<http://purl.obolibrary.org/obo/eco/eco-base.owl>)
 Import(<http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-caro.owl>)
 Import(<http://purl.obolibrary.org/obo/uberon/bridge/cl-bridge-to-caro.owl>)
 Import(<http://purl.obolibrary.org/obo/go/extensions/go-bfo-bridge.owl>)
-# Commented out on 2023-jun-19 by Gaurav: appears to be redundant with
-# http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl
-# Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl>)
+Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl>)
 Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl>)
 Import(<http://purl.obolibrary.org/obo/wbbt/wbbt-base.owl>)
 Import(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-base.owl>)

--- a/scripts/compact_iris.sc
+++ b/scripts/compact_iris.sc
@@ -1,6 +1,6 @@
 //> using scala "2.13"
-//> using dep "dev.zio::zio:2.0.10"
-//> using dep "dev.zio::zio-streams:2.0.10"
+//> using dep "dev.zio::zio:2.0.15"
+//> using dep "dev.zio::zio-streams:2.0.15"
 //> using dep "dev.zio::zio-json:0.5.0"
 
 import zio._

--- a/scripts/merge_noctua_models.sc
+++ b/scripts/merge_noctua_models.sc
@@ -1,8 +1,8 @@
 //> using scala "2.13"
-//> using dep "dev.zio::zio:2.0.12"
-//> using dep "dev.zio::zio-streams:2.0.12"
+//> using dep "dev.zio::zio:2.0.15"
+//> using dep "dev.zio::zio-streams:2.0.15"
 //> using dep "dev.zio::zio-json:0.5.0"
-//> using dep "org.apache.jena:apache-jena-libs:4.6.1"
+//> using dep "org.apache.jena:apache-jena-libs:4.8.0"
 
 import zio._
 import zio.Console._


### PR DESCRIPTION
This PR collects some changes needed to make kg-tsv run on Sterling:
- Increased ephemeral space to 10G so that we don't run out of it immediately.
- Moved Coursier cache into /workspace so that we don't use up our ephemeral space.
- Reduced build-cam-database-storage to 100G, since we only needed ~30G for the current build.
- Updated renciorg/cam-pipeline-tools from v1.4 to latest.
- scala-cli required some Maven packages be upgraded.
- Commented out http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl in favor of http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl (see #99 for details)

Also some general updates:
- Updated Biolink model to v3.4.3.

With these settings, I was able to set up a `debug-cam-database` pod on Sterling that I could run `make kg.tsv` in to obtain a kg.tsv file that consisted of 1,605,400 triples.

WIP: should be merged after PR https://github.com/ExposuresProvider/cam-pipeline/pull/97 and once https://github.com/obophenotype/ncbitaxon/issues/76 has been fixed.