### PR TITLE
Fix incorrect relation mapping

### DIFF
--- a/ro-to-biolink-local-mappings.tsv
+++ b/ro-to-biolink-local-mappings.tsv
@@ -58,7 +58,7 @@
 <http://purl.obolibrary.org/obo/RO_0002448>	<https://w3id.org/biolink/vocab/regulates>	narrow
 <http://purl.obolibrary.org/obo/RO_0002479>	<https://w3id.org/biolink/vocab/occurs_in>	broad
 <http://purl.obolibrary.org/obo/RO_0002500>	<https://w3id.org/biolink/vocab/causes>	narrow
-<http://purl.obolibrary.org/obo/RO_0002559>	<https://w3id.org/biolink/vocab/caused_by>	exact
+<http://purl.obolibrary.org/obo/RO_0002559>	<https://w3id.org/biolink/vocab/affected_by>	exact
 <http://purl.obolibrary.org/obo/RO_0002566>	<https://w3id.org/biolink/vocab/affects>	exact
 <http://purl.obolibrary.org/obo/RO_0002584>	<https://w3id.org/biolink/vocab/actively_involved_in>	broad
 <http://purl.obolibrary.org/obo/RO_0002588>	<https://w3id.org/biolink/vocab/has_output>	narrow


### PR DESCRIPTION
[causally influenced by](http://purl.obolibrary.org/obo/RO_0002559) should be mapped to `biolink:affected_by` rather than `biolink:caused_by`.

See https://github.com/NCATSTranslator/Feedback/issues/689.