### PR TITLE
Emit qualifiers with JSON output

### DIFF
--- a/scripts/compact_iris.sc
+++ b/scripts/compact_iris.sc
@@ -58,7 +58,7 @@ object Script extends ZIOAppDefault {
                 case other => {
                     throw new RuntimeException(s"Could not parse qualifier '$other' in line '$line'.")
                 }
-            }.toList.toJsonPretty
+            }.toList.toJson
             case other => other
         }.mkString("\t")
     }


### PR DESCRIPTION
Instead of writing the qualifiers out in our own funky format, I'm going to try to see if I can convert them into JSON format in compact_iris.sc.